### PR TITLE
refactor: use server-side supabase utility

### DIFF
--- a/api/gemini-proxy.ts
+++ b/api/gemini-proxy.ts
@@ -2,9 +2,17 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from '@supabase/supabase-js';
-import { supabaseUrl } from '../services/supabaseClient.js';
-import type { Database } from '../services/database.types.js';
-import type { Script, Trend, EnhancedTopic, VideoDeconstruction, ViralScoreBreakdown, OptimizationStep, Plan } from '../types.js';
+import { supabaseUrl } from '../services/supabaseServer';
+import type {
+  Database,
+  Script,
+  Trend,
+  EnhancedTopic,
+  VideoDeconstruction,
+  ViralScoreBreakdown,
+  OptimizationStep,
+  Plan,
+} from '../types';
 
 // Schemas
 const viralityAnalysisSchema = { type: Type.OBJECT, properties: { overallScore: { type: Type.NUMBER, description: "A score from 1-100 for overall viral potential." }, hookAnalysis: { type: Type.STRING, description: "1-sentence analysis of the hook's strength and attention-grabbing power." }, pacingAnalysis: { type: Type.STRING, description: "1-sentence analysis of the script's pacing, flow, and ability to hold attention." }, valueAnalysis: { type: Type.STRING, description: "1-sentence analysis of the value (entertainment, education, emotion) delivered to the viewer." }, ctaAnalysis: { type: Type.STRING, description: "1-sentence analysis of the call-to-action's effectiveness and clarity." }, finalVerdict: { type: Type.STRING, description: "A concluding one-sentence rationale for the overall score, summarizing the script's strongest and weakest points." } }, required: ["overallScore", "hookAnalysis", "pacingAnalysis", "valueAnalysis", "ctaAnalysis", "finalVerdict"] };

--- a/services/supabaseServer.ts
+++ b/services/supabaseServer.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '../types';
+
+export const supabaseUrl =
+  process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+
+if (!supabaseUrl) {
+  throw new Error('SUPABASE_URL environment variable is required');
+}
+
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+export const createSupabaseServerClient = (
+  key: string = serviceRoleKey as string
+) => {
+  if (!key) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is required');
+  }
+  return createClient<Database>(supabaseUrl, key);
+};
+
+export const supabaseServer =
+  serviceRoleKey ? createClient<Database>(supabaseUrl, serviceRoleKey) : null;


### PR DESCRIPTION
## Summary
- replace client-side Supabase imports in Gemini proxy with server-safe versions
- add `supabaseServer` utility for reading env vars without `window`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2146bce108330a03e6131604e8877